### PR TITLE
take PWP::Encoding away

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -147,7 +147,6 @@ Dist::Zilla::Plugin::Test::CPAN::Changes          = 0
 Dist::Zilla::Plugin::TestRelease                  = 0
 Dist::Zilla::PluginBundle::Git                    = 0
 Dist::Zilla::Role::PluginBundle::Merged           = 0
-Pod::Weaver::Plugin::Encoding                     = 0
 Pod::Weaver::Plugin::WikiDoc                      = 0
 Pod::Weaver::Section::Support                     = 0
 Test::CPAN::Meta                                  = 0

--- a/lib/Dist/Zilla/PluginBundle/Author/DBR.pm
+++ b/lib/Dist/Zilla/PluginBundle/Author/DBR.pm
@@ -222,7 +222,6 @@ This PluginBundle is roughly equivalent to the following C<dist.ini>:
     Dist::Zilla::Plugin::TestRelease                  = 0
     Dist::Zilla::PluginBundle::Git                    = 0
     Dist::Zilla::Role::PluginBundle::Merged           = 0
-    Pod::Weaver::Plugin::Encoding                     = 0
     Pod::Weaver::Plugin::WikiDoc                      = 0
     Test::CPAN::Meta                                  = 0
     Test::UseAllModules                               = 0

--- a/weaver.ini
+++ b/weaver.ini
@@ -1,5 +1,4 @@
 [@Default]
-[-Encoding]
 [-WikiDoc]
   comment_blocks = 1
 


### PR DESCRIPTION
Hi,

Pod::Weaver now [has _SingleEncoding_ plugin as a part of _@Default_ bundle (starting from 4.000)](http://rjbs.manxome.org/rubric/entry/2021), which makes Pod::Weaver::Plugin::Encoding an extra dependency that could be thrown away.

See my quest for details/comments:

> http://questhub.io/realm/perl/quest/5277f3cc9f567ad56f0000e7

Cheers,
Sergey
